### PR TITLE
DateField does not support `multi` and `date_format` at the same time

### DIFF
--- a/esengine/fields.py
+++ b/esengine/fields.py
@@ -250,13 +250,21 @@ class DateField(BaseField):
         return getattr(self, 'date_format', None)
 
     def to_dict(self, value, validate=True):
-        if validate:
+        if self._multi:
+            if not value:
+                return []
             self.validate(value)
-        if value:
+            if self._date_format:
+                return [x.strftime(self._date_format) for x in value]
+            return [x.isoformat() for x in value]
+        else:
+            if not value:
+                return None
+            if validate:
+                self.validate(value)
             if self._date_format:
                 return value.strftime(self._date_format)
-            else:
-                return value.isoformat()
+            return value.isoformat()
 
     def from_dict(self, serialized):
         if serialized:


### PR DESCRIPTION
When DateField override the to_dict() from BaseField it doesn't treat the multi case.

How to repeat:

```python
>>> from esengine import Document, DateField
>>> from elasticsearch import Elasticsearch
>>> from datetime import datetime
>>> class A(Document):
...     _index = 'A'
...     _doctype = 'A'
...     _es = Elasticsearch()
...     a = DateField(date_format='%Y-%m-%d', multi=True) 
>>> a = A(a=[datetime.now()])
>>> a.save()
Traceback (most recent call last):
  File "t.py", line 12, in <module>
    a.save()
  File "/usr/local/lib/python2.7/dist-packages/esengine/document.py", line 91, in save
    doc = self.to_dict()
  File "/usr/local/lib/python2.7/dist-packages/esengine/bases/document.py", line 79, in to_dict
    for field_name, field_instance in iteritems(fields)
  File "/usr/local/lib/python2.7/dist-packages/esengine/bases/document.py", line 79, in <dictcomp>
    for field_name, field_instance in iteritems(fields)
  File "/usr/local/lib/python2.7/dist-packages/esengine/fields.py", line 257, in to_dict
    return value.strftime(self._date_format)
AttributeError: 'list' object has no attribute 'strftime'
```